### PR TITLE
Add period command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ out a way to display the output publicly at some point.
 * `--user` : Last.fm username (defaults to "davorg")
 * `--count` : The number of artists to display (defaults to 10)
 * `--format` : The format to display results in. Can be "text", "html" or "json" (defaults to "text")
+* `--period` : The time period for the stats. Can be "overall", "7day", "1month", "3month", "6month", "12month" (defaults to "7day")

--- a/bin/laststats
+++ b/bin/laststats
@@ -13,7 +13,7 @@ if (@ARGV == 1) {
   $lastfm = App::LastFM::LastStats->new(username => $ARGV[0]);
 } else {
   my %opts;
-  GetOptions(\%opts, 'user=s', 'count=i', 'format=s');
+  GetOptions(\%opts, 'user=s', 'count=i', 'format=s', 'period=s');
 
   $lastfm = App::LastFM::LastStats->new(%opts);
 }

--- a/lib/App/LastFM/LastStats.pm
+++ b/lib/App/LastFM/LastStats.pm
@@ -30,6 +30,13 @@ class App::LastFM::LastStats {
   };
 
   method run {
+    GetOptions(
+      'user=s'   => \$username,
+      'period=s' => \$period,
+      'format=s' => \$format,
+      'count=i'  => \$count,
+    );
+
     $self->laststats;
     $self->render;
   }


### PR DESCRIPTION
Related to #1

Add a command line option to specify the period for the stats.

* **lib/App/LastFM/LastStats.pm**
  - Add `period` to the list of command line options in the `Getopt::Long` call.
  - Update the `run` method to use the value from the command line option if provided.
* **README.md**
  - Add `--period` to the list of command line options.
  - Mention that the `period` option allows specifying the time period for the stats.
  - List the available options for the `period` option: "overall", "7day", "1month", "3month", "6month", "12month".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/laststats/issues/1?shareId=d495c72b-7ea4-4591-b9e2-55c87e94f1ce).