### PR TITLE
Validate options before making requests

### DIFF
--- a/lib/App/LastFM/LastStats.pm
+++ b/lib/App/LastFM/LastStats.pm
@@ -37,8 +37,20 @@ class App::LastFM::LastStats {
       'count=i'  => \$count,
     );
 
+    $self->validate;
     $self->laststats;
     $self->render;
+  }
+
+  method validate {
+    my @valid_periods = qw(overall 7day 1month 3month 6month 12month);
+    unless (grep { $_ eq $period } @valid_periods) {
+      die "Invalid period: $period\n";
+    }
+
+    unless (exists $renderer->{$format}) {
+      die "Invalid format: $format\n";
+    }
   }
 
   method render_text {
@@ -64,11 +76,7 @@ class App::LastFM::LastStats {
   }
 
   method render {
-    my $method;
-    unless ($method = $renderer->{$format}) {
-      die "Invalid render format: $format\n";
-    }
-
+    my $method = $renderer->{$format};
     $self->$method;
   }
 


### PR DESCRIPTION
Related to #2

Add validation for `period` and `format` options before making requests.

* Add a `validate()` method to `lib/App/LastFM/LastStats.pm` to validate the `period` and `format` options.
* Call the `validate()` method in the `run` method before making requests.
* Validate the `period` option against the valid options: "overall", "7day", "1month", "3month", "6month", "12month".
* Validate the `format` option against the keys of the `$renderer` hash.
* Remove the existing validation of `$format` from the `render()` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/laststats/issues/2?shareId=a6e52816-d5b9-4dce-9b49-d6222accce62).