### PR TITLE
Lowercase option values in validate method

### DIFF
--- a/lib/App/LastFM/LastStats.pm
+++ b/lib/App/LastFM/LastStats.pm
@@ -43,6 +43,9 @@ class App::LastFM::LastStats {
   }
 
   method validate {
+    $period = lc $period;
+    $format = lc $format;
+
     my @valid_periods = qw(overall 7day 1month 3month 6month 12month);
     unless (grep { $_ eq $period } @valid_periods) {
       die "Invalid period: $period\n";


### PR DESCRIPTION
Related to #5

Convert the `format` and `period` options to lowercase in the `validate` method.

* Add lines to convert `$period` and `$format` to lowercase at the beginning of the `validate` method in `lib/App/LastFM/LastStats.pm`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/laststats/issues/5?shareId=245c9e01-4c52-41cc-999e-cbec360443ea).